### PR TITLE
watch 添加支持多个本地路径和remote路径的映射

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v8-hot-reload-kit",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "license": "MIT License",
   "author": "chexiongsheng <chexiongsheng@gmail.com>",
   "description": "hot-reload toolkit for v8 environment",


### PR DESCRIPTION
# 原本使用方式
```
npx v8-hot-reload-kit watch .babelbuild -h localhost -v -r InGamePath:JS --forceSrcType cjs -p 9229
```

# 新的方式
可以用| 分割本地路径，支持不同的远端路径和本地路径的映射
```
npx v8-hot-reload-kit watch ".babelbuild|.babelbuild\\MiniApp\\6942|.babelbuild\\MiniApp\\880" -h localhost -v -r "InGamePath:JS|MiniApp6942:JS|MiniApp880:JS" --forceSrcType cjs -p 9229
```