### PR TITLE
feat: 添加-s, --subDir <folder> ，可以在设置的本地目录下的多个一级子目录下进行搜索。

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v8-hot-reload-kit",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT License",
   "author": "chexiongsheng <chexiongsheng@gmail.com>",
   "description": "hot-reload toolkit for v8 environment",


### PR DESCRIPTION
# 原本使用方式
```
npx v8-hot-reload-kit watch ".babelbuild|.babelbuild\\MiniApp\\6942|.babelbuild\\MiniApp\\880" -h localhost -v -r "InGamePath:JS|MiniApp6942:JS|MiniApp880:JS" --forceSrcType cjs -p 9229
```
此时搜索的路径 是`.babelbuild`|`.babelbuild\\MiniApp\\6942`|`.babelbuild\\MiniApp\\880`

# 新增子目录搜索
```
npx v8-hot-reload-kit watch ".babelbuild|.babelbuild\\MiniApp\\6942|.babelbuild\\MiniApp\\880" -h localhost -v -r "InGamePath:JS|MiniApp6942:JS|MiniApp880:JS" --forceSrcType cjs -p 9229 -s "cn|en"
```
如果有设置-s 选项，
则先搜索 `.babelbuild\\cn`|`.babelbuild\\MiniApp\\6942\\cn`|`.babelbuild\\MiniApp\\880\\cn` 
再搜索`.babelbuild\\en`|`.babelbuild\\MiniApp\\6942\\en`|`.babelbuild\\MiniApp\\880\\en` 
如果都没有找到则 继续在`.babelbuild`|`.babelbuild\\MiniApp\\6942`|`.babelbuild\\MiniApp\\880` 中进行搜索